### PR TITLE
#25: Rename plugin to "SMNTCS Quantity Buttons for WooCommerce"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SMNTCS WooCommerce Quantity Buttons
+# SMNTCS Quantity Buttons for WooCommerce
 
 [![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level)
 [![Build Status](https://api.travis-ci.com/nielslange/smntcs-woocommerce-quantity-buttons.svg?branch=master)](https://api.travis-ci.com/nielslange/smntcs-woocommerce-quantity-buttons)
@@ -49,6 +49,7 @@ You can find the plugin on https://wordpress.org/plugins/smntcs-woocommerce-quan
 
 ### 1.15
 * [Fix nulled product quantity after release 1.14](https://github.com/nielslange/smntcs-woocommerce-quantity-buttons/issues/24)
+* [Rename plugin to "SMNTCS Quantity Buttons for WooCommerce"](https://github.com/nielslange/smntcs-woocommerce-quantity-buttons/issues/25)
 
 ### 1.14
 * [Add compatibility for grouped products](https://github.com/nielslange/smntcs-woocommerce-quantity-buttons/issues/21)

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-=== SMNTCS WooCommerce Quantity Buttons ===
+=== SMNTCS Quantity Buttons for WooCommerce ===
 
 Contributors: nielslange, derweltbuerger, marcqueralt
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=H8FCEN4TDSYBN
@@ -14,7 +14,7 @@ Display quantity buttons on WooCommerce product page
 
 == Description ==
 
-WooCommerce Quantity Buttons adds two additional buttons to the quantity input field on the WooCommerce product page to easily increase and decrease the quantity via button click.
+SMNTCS Quantity Buttons for WooCommerce adds two additional buttons to the quantity input field on the WooCommerce product page to easily increase and decrease the quantity via button click.
 
 === Compatible with ===
 
@@ -67,6 +67,7 @@ Contributions are more than welcome. Simply head over to [Github](https://github
 
 = 1.15 =
 * [Fix nulled product quantity after release 1.14](https://github.com/nielslange/smntcs-woocommerce-quantity-buttons/issues/24)
+* [Rename plugin to "SMNTCS Quantity Buttons for WooCommerce"](https://github.com/nielslange/smntcs-woocommerce-quantity-buttons/issues/25)
 
 = 1.14 =
 * [Add compatibility for grouped products](https://github.com/nielslange/smntcs-woocommerce-quantity-buttons/issues/21)

--- a/woocommerce-quantity-buttons.php
+++ b/woocommerce-quantity-buttons.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: SMNTCS WooCommerce Quantity Buttons
+ * Plugin Name: SMNTCS Quantity Buttons for WooCommerce
  * Plugin URI: https://github.com/nielslange/smntcs-woocommerce-quantity-buttons
  * Description: Add quantity buttons to WooCommerce product page
  * Author: Niels Lange <info@nielslange.de>
@@ -16,7 +16,7 @@
  *
  * @category   Plugin
  * @package    WordPress
- * @subpackage SMNTCS WooCommerce Quantity Buttons
+ * @subpackage SMNTCS Quantity Buttons for WooCommerce
  * @author     Niels Lange <info@nielslange.de>
  * @license    http://opensource.org/licenses/gpl-license.php GNU Public License
  */
@@ -49,7 +49,7 @@ add_action(
 
 		if ( ! class_exists( 'WooCommerce' ) || version_compare( $woocommerce->version, '2.3', '<' ) ) {
 			$class   = 'notice notice-warning is-dismissible';
-			$message = __( 'SMNTCS WooCommerce Quantity Buttons requires at least WooCommerce 2.3.', 'smntcs-woocommerce-quantity-buttons' );
+			$message = __( 'SMNTCS Quantity Buttons for WooCommerce requires at least WooCommerce 2.3.', 'smntcs-woocommerce-quantity-buttons' );
 
 			printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
 		}


### PR DESCRIPTION
Fixes #25 