### PR TITLE
Add toggle to use <button> instead of <input type="button">

### DIFF
--- a/assets/js/button-handler.js
+++ b/assets/js/button-handler.js
@@ -17,7 +17,9 @@ jQuery( function ( $ ) {
 		};
 	}
 
-	$( document ).on( 'click', '.plus, .minus', function () {
+	$( document ).on( 'click', '.plus, .minus', function ( event ) {
+		event.preventDefault();
+
 		// Get values
 		var qty = $( this ).closest( '.quantity' ).find( '.qty' ),
 			currentVal = parseFloat( qty.val() ),

--- a/template/global/quantity-input.php
+++ b/template/global/quantity-input.php
@@ -16,11 +16,11 @@
  * @version     3.3.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+// Avoid direct plugin access.
+defined( 'ABSPATH' ) || exit;
 
 $flip_quantity_buttons = apply_filters( 'flip_quantity_buttons', false );
+$use_html_buttons      = apply_filters( 'use_html_buttons', false );
 
 if ( $max_value && $min_value === $max_value ) {
 	?>
@@ -45,26 +45,47 @@ if ( $max_value && $min_value === $max_value ) {
 	?>
 	<div class="quantity">
 		<label class="screen-reader-text" for="smntcswcb"><?php esc_html_e( 'Quantity', 'smntcs-quantity-buttons-for-woocommerce' ); ?></label>
+
 		<?php if ( $flip_quantity_buttons ) : ?>
-			<input class="plus button wp-element-button" type="button" value="+">
+			<?php if ( $use_html_buttons ) : ?>
+				<button class="plus button wp-element-button">+</button>
+			<?php else : ?>
+				<input class="plus button wp-element-button" type="button" value="+">
+			<?php endif ?>
 		<?php else : ?>
-			<input class="minus button wp-element-button" type="button" value="-">
+			<?php if ( $use_html_buttons ) : ?>
+				<button class="minus button wp-element-button">-</button>
+			<?php else : ?>
+				<input class="minus button wp-element-button" type="button" value="-">
+			<?php endif ?>
 		<?php endif ?>
+
 		<input type="number"
-					id="smntcswcb" step="<?php echo esc_attr( $step ); ?>" min="<?php echo esc_attr( $min_value ); ?>"
-					<?php if ( isset( $max_value ) && 0 < $max_value ) : ?>
-						max="<?php echo esc_attr( $max_value ); ?>"
-					<?php endif; ?>
-					name="<?php echo esc_attr( $input_name ); ?>"
-					value="<?php echo esc_attr( $input_value ); ?>"
-					title="<?php echo esc_attr_x( 'Qty', 'Product quantity input tooltip', 'smntcs-quantity-buttons-for-woocommerce' ); ?>"
-					class="input-text qty text"
-					inputmode="<?php echo esc_attr( $inputmode ); ?>" />
+			id="smntcswcb" step="<?php echo esc_attr( $step ); ?>"
+			min="<?php echo esc_attr( $min_value ); ?>"
+			<?php if ( isset( $max_value ) && 0 < $max_value ) : ?>
+				max="<?php echo esc_attr( $max_value ); ?>"
+			<?php endif; ?>
+			name="<?php echo esc_attr( $input_name ); ?>"
+			value="<?php echo esc_attr( $input_value ); ?>"
+			title="<?php echo esc_attr_x( 'Qty', 'Product quantity input tooltip', 'smntcs-quantity-buttons-for-woocommerce' ); ?>"
+			class="input-text qty text"
+			inputmode="<?php echo esc_attr( $inputmode ); ?>" />
+
 		<?php if ( $flip_quantity_buttons ) : ?>
-			<input class="minus button wp-element-button" type="button" value="-">
+			<?php if ( $use_html_buttons ) : ?>
+				<button class="minus button wp-element-button">-</button>
+			<?php else : ?>
+				<input class="minus button wp-element-button" type="button" value="-">
+			<?php endif ?>
 		<?php else : ?>
-			<input class="plus button wp-element-button" type="button" value="+">
+			<?php if ( $use_html_buttons ) : ?>
+				<button class="plus button wp-element-button">+</button>
+			<?php else : ?>
+				<input class="plus button wp-element-button" type="button" value="+">
+			<?php endif ?>
 		<?php endif ?>
+
 	</div>
 	<?php
 }


### PR DESCRIPTION
Fixes #90

In https://wordpress.org/support/topic/template-override-not-working-8/, a user asked how to overwrite the template respectively how to change `<input type="button">` to `<button>`. This PR aims to a toggle to use `<button>` instead of `<input type="button">`.

### Testing instructions:

- Install and activate the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin.
- Add PHP filter `add_filter( 'use_html_buttons', '__return_true' );`.
- Go to a product page and verify that the button elements instead of input elements are visible.
- Also verify that the quantity can still be changed.
- Add the product to the cart and repeat the previous two steps.